### PR TITLE
Add reuse license compliance

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: CC0-1.0
+
 /* eslint-env node */
 require('@rushstack/eslint-patch/modern-module-resolution')
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # Logs
 logs
 *.log

--- a/.prettierrc.json.license
+++ b/.prettierrc.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,17 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: supportmodalapp
+Source: https://github.com/diggsweden/supportmodalapp
+
+Files: package*.json **/*.json 
+Copyright: Digg - Agency for Digital Government
+License: CC0-1.0
+
+Files: public/*.ico src/assets/*.svg
+Copyright: Digg- Agency for Digital Government
+License: CC0-1.0
+
+# Third-party files
+
+Files: src/assets/Lato-Regular.ttf
+Copyright: tyPoland Lukasz Dziedzic
+License: OFL-1.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # build stage
 FROM node:lts-alpine as build-stage
 WORKDIR /app

--- a/LICENSES/OFL-1.1.txt
+++ b/LICENSES/OFL-1.1.txt
@@ -1,0 +1,43 @@
+SIL OPEN FONT LICENSE
+
+Version 1.1 - 26 February 2007
+
+PREAMBLE
+
+The goals of the Open Font License (OFL) are to stimulate worldwide development of collaborative font projects, to support the font creation efforts of academic and linguistic communities, and to provide a free and open framework in which fonts may be shared and improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and redistributed freely as long as they are not sold by themselves. The fonts, including any derivative works, can be bundled, embedded, redistributed and/or sold with any software provided that any reserved names are not used by derivative works. The fonts and derivatives, however, cannot be released under any other type of license. The requirement for fonts to remain under this license does not apply to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+
+"Font Software" refers to the set of files released by the Copyright Holder(s) under this license and clearly marked as such. This may include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting, or substituting — in part or in whole — any of the components of the Original Version, by changing formats or by porting the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of the Font Software, to use, study, copy, merge, embed, modify, redistribute, and sell modified and unmodified copies of the Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled, redistributed and/or sold with any software, provided that each copy contains the above copyright notice and this license. These can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font Name(s) unless explicit written permission is granted by the corresponding Copyright Holder. This restriction only applies to the primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font Software shall not be used to promote, endorse or advertise any Modified Version, except to acknowledge the contribution(s) of the Copyright Holder(s) and the Author(s) or with their explicit written permission.
+
+5) The Font Software, modified or unmodified, in part or in whole, must be distributed entirely under this license, and must not be distributed under any other license. The requirement for fonts to remain under this license does not apply to any document created using the Font Software.
+
+TERMINATION
+
+This license becomes null and void if any of the above conditions are not met.
+
+DISCLAIMER
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # Define variables
 CONTAINER_NAME = digg-support-modal-app
 IMAGE_NAME = digg-support-modal-app-image

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 # SupportModalApp
+
+[![REUSE status](https://api.reuse.software/badge/github.com/diggsweden/supportmodalapp)](https://api.reuse.software/info/github.com/diggsweden/supportmodalapp)
+
 
 Welcome to the SupportModalApp project! This repository houses a small web application designed to enhance user experience with interactive support actions.
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import { defineConfig } from 'cypress'
 
 export default defineConfig({

--- a/cypress/e2e/example.cy.js
+++ b/cypress/e2e/example.cy.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 // https://on.cypress.io/api
 
 describe('My First Test', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 // ***********************************************************
 // This example support/index.js is processed and
 // loaded automatically before your test files.

--- a/index.html
+++ b/index.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 <!doctype html>
 <html lang="en">
   <head>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: MIT
+-->
+
 <template>
   <div class="modal-container">
     <ModalMenuContainer

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 @font-face {
 	font-family: 'Lato';
 	src: local('Lato'), url(./Lato-Regular.ttf) format('truetype');

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 @import './base.css';
 
 #app {

--- a/src/availableItems.js
+++ b/src/availableItems.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 /* eslint-disable no-undef */
 import chatIcon from '@/assets/chat-smile-2-line.svg'
 import supportIcon from '@/assets/customer-service-2-fill.svg'

--- a/src/components/__tests__/AccordionMenu.spec.jsx
+++ b/src/components/__tests__/AccordionMenu.spec.jsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import { shallowMount } from '@vue/test-utils'
 import { it, expect } from 'vitest'
 import AccordionMenu from '@/components/modal/AccordionMenu.vue'

--- a/src/components/__tests__/App.spec.jsx
+++ b/src/components/__tests__/App.spec.jsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 // App.test.js
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';

--- a/src/components/__tests__/ModalMenu.spec.jsx
+++ b/src/components/__tests__/ModalMenu.spec.jsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import { shallowMount } from '@vue/test-utils'
 import { it, expect, describe } from 'vitest'
 import ModalMenuContainer from '@/components/modal/ModalMenuContainer.vue'

--- a/src/components/icons/IconCommunity.vue
+++ b/src/components/icons/IconCommunity.vue
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: MIT
+-->
+
 <template>
   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor">
     <path

--- a/src/components/icons/IconDocumentation.vue
+++ b/src/components/icons/IconDocumentation.vue
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: MIT
+-->
+
 <template>
   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="17" fill="currentColor">
     <path

--- a/src/components/icons/IconEcosystem.vue
+++ b/src/components/icons/IconEcosystem.vue
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: MIT
+-->
+
 <template>
   <svg xmlns="http://www.w3.org/2000/svg" width="18" height="20" fill="currentColor">
     <path

--- a/src/components/icons/IconSupport.vue
+++ b/src/components/icons/IconSupport.vue
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: MIT
+-->
+
 <template>
   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor">
     <path

--- a/src/components/icons/IconTooling.vue
+++ b/src/components/icons/IconTooling.vue
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: MIT
+-->
+
 <!-- This icon is from <https://github.com/Templarian/MaterialDesign>, distributed under Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0) license-->
 <template>
   <svg

--- a/src/components/modal/AccordionMenu.vue
+++ b/src/components/modal/AccordionMenu.vue
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: MIT
+-->
+
 <template>
   <div class="icon-list-wrapper">
     <button

--- a/src/components/modal/ModalMenuContainer.vue
+++ b/src/components/modal/ModalMenuContainer.vue
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: MIT
+-->
+
 <template>
   <div class="rectangle">
     <div class="modal-header">

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import i18next from 'i18next'
 import I18NextVue from 'i18next-vue'
 import LanguageDetector from 'i18next-browser-languagedetector'

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import './assets/main.css'
 
 import { createApp } from 'vue'

--- a/src/services/PostMessageService.js
+++ b/src/services/PostMessageService.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 class PostMessageService {
   constructor() {
     this.eventHandlers = {}

--- a/src/services/eventBus.js
+++ b/src/services/eventBus.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 // eventBus.js
 import mitt from 'mitt'
 const emitter = mitt()

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import { config } from '@vue/test-utils'
 
 class MockResizeObserver {

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 /**
  * Debounce function
  * @param {Function} func - Function to be executed

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import { fileURLToPath, URL } from 'node:url'
 
 import { defineConfig } from 'vite'

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 import { fileURLToPath } from 'node:url'
 import { mergeConfig, defineConfig, configDefaults } from 'vitest/config'
 import viteConfig from './vite.config'


### PR DESCRIPTION
This PR makes the project license declare licenses according to https://reuse.software/ so that it passes the reuse lint.

Even though it is many affected files, the pr is scroll friendly and contains no logic. It should hopefully be a quick general overview before merging it.

Basically, it adds license headers in spdx-format, as per the reuse-specification. It also adds a missing reuse LICENSES file, ofl 1.1, and the .reuse/dep5 which takes care of the licening of json files etc.

Note: the reuse badge in the README will be green when the project is public

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
